### PR TITLE
#28 Feat: Delete many tutorials

### DIFF
--- a/src/tutorials/tutorials.controller.spec.ts
+++ b/src/tutorials/tutorials.controller.spec.ts
@@ -42,6 +42,7 @@ describe('TutorialsController', () => {
               .mockResolvedValue(mockTutorialEntityList[0]),
             updateTutorial: jest.fn().mockResolvedValue(mockUpdateTutorialDto),
             deleteTutorial: jest.fn().mockResolvedValue('Deletado com sucesso'),
+            deleteTutorials: jest.fn().mockResolvedValue('Deletados com sucesso'),
           },
         },
       ],
@@ -123,4 +124,41 @@ describe('TutorialsController', () => {
       expect(service.deleteTutorial).toHaveBeenCalledWith(id);
     });
   });
+
+  // Create two mocks for deleteTutorials
+  const mockTutorials = [
+    {
+      id: '1',
+      name: 'mockStation',
+      category_id: mockUuid,
+      filename: 'mockFile',
+      data: [37, 80, 68, 70, 45, 49, 46, 52, 10, 37, 226, 227, 207, 211, 10]
+    },
+    {
+      id: '2',
+      name: 'mockStation',
+      category_id: mockUuid,
+      filename: 'mockFile',
+      data: [37, 80, 68, 70, 45, 49, 46, 52, 10, 37, 226, 227, 207, 211, 10]
+    }
+  ];
+
+
+  describe('deleteManyTutorials', () => {
+    it('should delete many tutorial entities succesfully', async () => {
+
+
+      const ids = mockTutorials.map(tutorial => tutorial.id);
+
+      const result = await controller.deleteTutorials(ids);
+
+      expect(result).toMatch('Deletados com sucesso');
+
+      expect(service.deleteTutorials).toHaveBeenCalledTimes(1);
+
+      expect(service.deleteTutorials).toHaveBeenCalledWith(ids);
+    });
+  }
+  );
+
 });

--- a/src/tutorials/tutorials.controller.ts
+++ b/src/tutorials/tutorials.controller.ts
@@ -9,6 +9,7 @@ import {
   UseInterceptors,
   CacheInterceptor,
   UploadedFile,
+  ParseArrayPipe,
 } from '@nestjs/common';
 import { TutorialsService } from './tutorials.service';
 import { CreateTutorialDto } from './dto/create-tutorial.dto';
@@ -66,5 +67,13 @@ export class TutorialsController {
   @Delete(':id')
   async deleteTutorial(@Param('id') id: string): Promise<string> {
     return await this.tutorialService.deleteTutorial(id);
+  }
+
+  // Rota para excluir lista de tutoriais cadastrados em lote
+  @Delete(
+    'delete-tutorials/:ids',
+  )
+  async deleteTutorials(@Param('ids', ParseArrayPipe) ids: string[]): Promise<string> {
+    return await this.tutorialService.deleteTutorials(ids);
   }
 }

--- a/src/tutorials/tutorials.service.ts
+++ b/src/tutorials/tutorials.service.ts
@@ -104,4 +104,14 @@ export class TutorialsService {
       throw new InternalServerErrorException(err.message);
     }
   }
+
+  // Deleta uma lista de tutoriais
+  async deleteTutorials(ids: string[]): Promise<string> {
+    try {
+      await this.tutorialRepo.delete(ids);
+      return 'Deletados com sucesso';
+    } catch (err) {
+      throw new InternalServerErrorException(err.message);
+    }
+  }
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Foi criado um endpoint para remover mais de um tutorial por vez.

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

[Issue #28](https://github.com/fga-eps-mds/2023-1-Schedula-Doc/issues/28)

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

Adicione mais de um tutorial, capture o is deles por meio do postman:

Depois faça a requisição utilizando a porta que está utilizando para fazer a deleção:

http://localhost:3004/tutorials/delete-tutorials/8bfe8ed9-1a19-477e-8bfd-10c97d7a00dc,b3c50ff8-7544-4416-83fe-aa70a27bfb05

Basta colocar o id dos tutoriais separados por vírgula

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
